### PR TITLE
EXM-32 Make conversion rates fetch at start

### DIFF
--- a/expenses-manager-backend/src/main/java/com/endava/expensesmanager/ExpensesManagerBackendApplication.java
+++ b/expenses-manager-backend/src/main/java/com/endava/expensesmanager/ExpensesManagerBackendApplication.java
@@ -2,8 +2,10 @@ package com.endava.expensesmanager;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ExpensesManagerBackendApplication {
 
     public static void main(String[] args) {

--- a/expenses-manager-backend/src/main/java/com/endava/expensesmanager/service/impl/CurrencyConversionServiceImpl.java
+++ b/expenses-manager-backend/src/main/java/com/endava/expensesmanager/service/impl/CurrencyConversionServiceImpl.java
@@ -1,17 +1,29 @@
 package com.endava.expensesmanager.service.impl;
 
+import com.endava.expensesmanager.entity.Currency;
 import com.endava.expensesmanager.exception.BadRequestException;
+import com.endava.expensesmanager.repository.CurrencyRepository;
 import com.endava.expensesmanager.service.CurrencyConversionService;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 public class CurrencyConversionServiceImpl implements CurrencyConversionService {
 
     private final RestTemplate restTemplate;
+
+    private final Map<String, Map<String, Double>> exchangeRatesCache = new HashMap<>();
+
+    private final CurrencyRepository currencyRepository;
 
     @Value("${api.currency.url}")
     private String apiCurrencyUrl;
@@ -19,8 +31,43 @@ public class CurrencyConversionServiceImpl implements CurrencyConversionService 
     @Value("${api.currency.key}")
     private String apiKey;
 
-    public CurrencyConversionServiceImpl(RestTemplate restTemplate) {
+    public CurrencyConversionServiceImpl(RestTemplate restTemplate, CurrencyRepository currencyRepository) {
         this.restTemplate = restTemplate;
+        this.currencyRepository = currencyRepository;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void loadExchangeRatesOnStartup() {
+        loadExchangeRates();
+    }
+
+    @Scheduled(cron = "0 0 0 * * MON")
+    public void loadExchangeRates(){
+        try {
+            List<Currency> currencies = currencyRepository.findAll();
+            for (Currency baseCurrency: currencies) {
+                String url = String.format("%s/%s/latest/%s", apiCurrencyUrl, apiKey, baseCurrency.getCode());
+                CurrencyResponse response = restTemplate.getForObject(url, CurrencyResponse.class);
+
+                if (response != null && "success".equals(response.getResult())) {
+                    Map<String, Double> rates = response.getConversionRates();
+
+                    Map<String, Double> filteredRates = new HashMap<>();
+                    for (Currency toCurrency: currencies) {
+                        if (!baseCurrency.equals(toCurrency) && rates.containsKey(toCurrency.getCode())) {
+                            filteredRates.put(toCurrency.getCode(), rates.get(toCurrency.getCode()));
+                        }
+                    }
+
+                    exchangeRatesCache.put(baseCurrency.getCode(), filteredRates);
+                }
+                else{
+                    throw new BadRequestException("Failed to load rates for base currency: " + baseCurrency.getCode());
+                }
+            }
+        } catch (Exception e){
+            e.printStackTrace();
+        }
     }
 
     @Override
@@ -33,17 +80,14 @@ public class CurrencyConversionServiceImpl implements CurrencyConversionService 
             return amount;
         }
 
-        String url = String.format("%s/%s/pair/%s/%s", apiCurrencyUrl, apiKey, fromCurrency, toCurrency);
-
-        CurrencyResponse response = restTemplate.getForObject(url, CurrencyResponse.class);
-
-        if (response == null || !"success".equals(response.getResult())) {
-            throw new BadRequestException("Failed to get conversion rates from API");
+        Map<String, Double> rates = exchangeRatesCache.get(fromCurrency);
+        if (rates == null) {
+            throw new BadRequestException("No exchange rates available for currency: " + fromCurrency);
         }
 
-        Double conversionRate = response.getConversionRate();
+        Double conversionRate = rates.get(toCurrency);
         if (conversionRate == null) {
-            throw new BadRequestException("Invalid conversion rate received");
+            throw new BadRequestException("No exchange rate found for conversion from " + fromCurrency + " to " + toCurrency);
         }
 
         return amount.multiply(BigDecimal.valueOf(conversionRate));

--- a/expenses-manager-backend/src/main/java/com/endava/expensesmanager/service/impl/CurrencyConversionServiceImpl.java
+++ b/expenses-manager-backend/src/main/java/com/endava/expensesmanager/service/impl/CurrencyConversionServiceImpl.java
@@ -41,7 +41,7 @@ public class CurrencyConversionServiceImpl implements CurrencyConversionService 
         loadExchangeRates();
     }
 
-    @Scheduled(cron = "0 0 0 * * MON")
+    @Scheduled(cron = "0 0 0 * * ?")
     public void loadExchangeRates(){
         try {
             List<Currency> currencies = currencyRepository.findAll();
@@ -60,9 +60,6 @@ public class CurrencyConversionServiceImpl implements CurrencyConversionService 
                     }
 
                     exchangeRatesCache.put(baseCurrency.getCode(), filteredRates);
-                }
-                else{
-                    throw new BadRequestException("Failed to load rates for base currency: " + baseCurrency.getCode());
                 }
             }
         } catch (Exception e){

--- a/expenses-manager-backend/src/main/java/com/endava/expensesmanager/service/impl/CurrencyResponse.java
+++ b/expenses-manager-backend/src/main/java/com/endava/expensesmanager/service/impl/CurrencyResponse.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Map;
+
 @Getter
 @Setter
 public class CurrencyResponse {
@@ -12,9 +14,6 @@ public class CurrencyResponse {
     @JsonProperty("base_code")
     private String baseCode;
 
-    @JsonProperty("target_code")
-    private String targetCode;
-
-    @JsonProperty("conversion_rate")
-    private Double conversionRate;
+    @JsonProperty("conversion_rates")
+    private Map<String, Double> conversionRates;
 }

--- a/expenses-manager-backend/src/main/resources/application.properties
+++ b/expenses-manager-backend/src/main/resources/application.properties
@@ -5,4 +5,4 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.sql.init.mode=always
 spring.jpa.defer-datasource-initialization=true
 api.currency.url=https://v6.exchangerate-api.com/v6
-api.currency.key=648eddb87953dc6a0adcda6f
+api.currency.key=4615f06c95a06b75a7e052f7


### PR DESCRIPTION
- Only 10 requests are made at start, one for each currency in the database
- Rates are also fetched every Monday
- Changed API key to one that is not out of requests